### PR TITLE
Update Neo-tree key mappings

### DIFF
--- a/.config/nvim/lua/plugins/neotree.lua
+++ b/.config/nvim/lua/plugins/neotree.lua
@@ -26,6 +26,11 @@ return {
       end,
     },
   },
+  keys = {
+    { '<leader>e', '<cmd>Neotree toggle position=left<CR>', desc = 'Toggle Neo-tree' },
+    { '\\', '<cmd>Neotree reveal<CR>', desc = 'Reveal file in Neo-tree' },
+    { '<leader>ngs', '<cmd>Neotree float git_status<CR>', desc = 'Neo-tree git status' },
+  },
   config = function()
     -- If you want icons for diagnostic errors, you'll need to define them somewhere:
     vim.fn.sign_define('DiagnosticSignError', { text = ' ', texthl = 'DiagnosticSignError' })
@@ -308,8 +313,5 @@ return {
       },
     }
 
-    vim.cmd [[nnoremap \ :Neotree reveal<cr>]]
-    vim.keymap.set('n', '<leader>e', ':Neotree toggle position=left<CR>', { noremap = true, silent = true }) -- focus file explorer
-    vim.keymap.set('n', '<leader>ngs', ':Neotree float git_status<CR>', { noremap = true, silent = true }) -- open git status window
   end,
 }


### PR DESCRIPTION
## Summary
- configure Neo-tree plugin to use lazy.nvim keys
- remove redundant mappings in the config block

## Testing
- `./setup.sh --help`

------
https://chatgpt.com/codex/tasks/task_e_6849e0cdcc1c832db6f1c6f293297eb5