### PR TITLE
Update Avante config for new provider settings

### DIFF
--- a/.config/lvim/lua/jduque/plugins.lua
+++ b/.config/lvim/lua/jduque/plugins.lua
@@ -63,13 +63,17 @@ lvim.plugins = {
     build = "make",                             -- Use `make` to build Avante.nvim
     opts = {
       provider = "openai",
-      openai = {
-        -- endpoint = "https://api.openai.com/v1",
-        model = "gpt-4o-mini",
-        -- timeout = 30000,
-        -- temperature = 0,
-        -- max_tokens = 4096,
-        -- api_key = os.getenv("OPENAI_API_KEY"), -- Load API key from environment variable
+      providers = {
+        openai = {
+          -- endpoint = "https://api.openai.com/v1",
+          model = "gpt-4o-mini",
+          -- timeout = 30000,
+          extra_request_body = {
+            -- temperature = 0,
+            -- max_completion_tokens = 4096,
+          },
+          -- api_key = os.getenv("OPENAI_API_KEY"), -- Load API key from environment variable
+        },
       },
     },
     dependencies = {

--- a/.config/nvim/lua/plugins/avante.lua
+++ b/.config/nvim/lua/plugins/avante.lua
@@ -5,12 +5,16 @@ return {
   version = false,
   opts = {
     provider = 'openai',
-    openai = {
-      endpoint = 'https://api.openai.com/v1',
-      model = 'gpt-4o-mini',
-      timeout = 30000, -- Timeout in milliseconds, increase this for reasoning models
-      temperature = 0,
-      max_completion_tokens = 8192,
+    providers = {
+      openai = {
+        endpoint = 'https://api.openai.com/v1',
+        model = 'gpt-4o-mini',
+        timeout = 30000, -- Timeout in milliseconds, increase this for reasoning models
+        extra_request_body = {
+          temperature = 0,
+          max_completion_tokens = 8192,
+        },
+      },
     },
   },
   -- if you want to build from source then do `make BUILD_FROM_SOURCE=true`


### PR DESCRIPTION
## Summary
- update Avante.nvim config for new providers.openai format
- update LunarVim plugin config accordingly

## Testing
- `stylua .config/nvim/lua/plugins/avante.lua .config/lvim/lua/jduque/plugins.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b84f8efd0832da64d45534210a5bc